### PR TITLE
Bugfix: The library produces E500

### DIFF
--- a/saetv2.ex.class.php
+++ b/saetv2.ex.class.php
@@ -6,12 +6,16 @@
  */
 
 /**
+ * If the class OAuthException has not been declared, extend the Exception class.
+ * This is to allow OAuth without the PECL OAuth library
+ * 
  * @ignore
  */
-class OAuthException extends Exception {
-	// pass
+if ( ! class_exists( 'OAuthException')) {
+	class OAuthException extends Exception {
+		// pass
+	}
 }
-
 
 /**
  * 新浪微博 OAuth 认证类(OAuth2)


### PR DESCRIPTION
When the OAuth PECL library is installed, the libweibo library produces an error because it is trying to create an OAuthException class when it has been created already.
This fixes that.