### PR TITLE
调整 saetv2.ex.class.php 类 function getAccessToken 方法（函数）默认参数的不正确用法

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/saetv2.ex.class.php
+++ b/saetv2.ex.class.php
@@ -172,14 +172,14 @@ class SaeTOAuthV2 {
 	 *
 	 * 对应API：{@link http://open.weibo.com/wiki/OAuth2/access_token OAuth2/access_token}
 	 *
-	 * @param string $type 请求的类型,可以为:code, password, token
 	 * @param array $keys 其他参数：
 	 *  - 当$type为code时： array('code'=>..., 'redirect_uri'=>...)
 	 *  - 当$type为password时： array('username'=>..., 'password'=>...)
 	 *  - 当$type为token时： array('refresh_token'=>...)
-	 * @return array
+     * @param string $type 请求的类型,可以为:code, password, token
+     * @return array
 	 */
-	function getAccessToken( $type = 'code', $keys ) {
+	function getAccessToken($keys,$type = 'code' ) {
 		$params = array();
 		$params['client_id'] = $this->client_id;
 		$params['client_secret'] = $this->client_secret;


### PR DESCRIPTION
## 函数默认参数的不正确用法
```php
function getAccessToken($type = 'code'，$keys)
{
    return "Making a bowl of $type $keys.\n";
}
echo getAccessToken("raspberry");   // won't work as expected
```
> 以上例程会输出
```php
Warning: Missing argument 2 in call to makeyogurt() in 
/usr/local/etc/httpd/htdocs/phptest/functest.html on line 41
Making a bowl of raspberry .
```
## 函数默认参数正确的用法
```php
function getAccessToken($keys,$type = 'code' )
{
    return "Making a bowl of $type $keys.\n";
}
echo getAccessToken("raspberry");   // works as expected
```
## [PHP官方文档](http://php.net/manual/zh/functions.arguments.php)