### PR TITLE
Update saetv2.ex.class.php

### DIFF
--- a/saetv2.ex.class.php
+++ b/saetv2.ex.class.php
@@ -454,7 +454,7 @@ class SaeTOAuthV2 {
 
 		foreach ($params as $parameter => $value) {
 
-			if( in_array($parameter, array('pic', 'image')) && $value{0} == '@' ) {
+			if( in_array($parameter, array('pic', 'image')) && $value[0] == '@' ) {
 				$url = ltrim( $value, '@' );
 				$content = file_get_contents( $url );
 				$array = explode( '?', basename( $url ) );


### PR DESCRIPTION
修正 Array and string offset access syntax with curly braces is deprecated